### PR TITLE
Correct syntax error with Knot client string in App.cpp

### DIFF
--- a/MC.Xbox/App.cpp
+++ b/MC.Xbox/App.cpp
@@ -544,7 +544,7 @@ static bool RunEmbeddedMinecraft(const std::wstring& exeDir,
         return false;
     }
 
-    jclass mainClass = env->FindClass("net/fabricmc/loader/impl/launch/knot/KnotClient");
+    jclass mainClass = env->FindClass("net.fabricmc.loader.impl.launch.knot.KnotClient");
     if (!mainClass || CheckAndLogJavaException(env, L"FindClass(KnotClient)")) {
         return false;
     }


### PR DESCRIPTION
Fixes the CallStaticVoidMethod error when launching
Thanks to @Gale2222!